### PR TITLE
Revert "Scrolldown" change for when first named

### DIFF
--- a/releaseNotes.scroll
+++ b/releaseNotes.scroll
@@ -635,7 +635,7 @@ list
 
 section 7.0.0 04-03-2021
 list
- - ⚠️ Scroll the language is now called ScrollScript (thanks FB!).
+ - ⚠️ Scroll the language is now called Scrolldown (thanks FB!).
  - 🏥 Bug fixes.
  - 🎉 Better perf.
 


### PR DESCRIPTION
Hi Breck (@breck7),

In [fefa82c](https://github.com/breck7/scroll/commit/fefa82c6a66ef359266aa48821ab82a0cde037cc), you acknowledged the change of name to "Scrolldown" and that FB was the source of the change. I believe that this should be retained to show the history and the progression of the language.

Kind Regards,
Liam