### PR TITLE
chore(typos): add CI and fix typos

### DIFF
--- a/.github/workflows/fix-typos.yml
+++ b/.github/workflows/fix-typos.yml
@@ -1,0 +1,19 @@
+name: Automatically fix typos
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - uses: sobolevn/misspell-fixer-action@master
+      - uses: peter-evans/create-pull-request@v4.2.0
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/kitchenSink/about.scroll
+++ b/tests/kitchenSink/about.scroll
@@ -2,7 +2,7 @@ import header.scroll
 
 title About the Kitchen Sink Blog
 
-* This blog is for testing purposes—to excercise/test all the features of Scroll.
+* This blog is for testing purposes—to exercise/test all the features of Scroll.
 
 groups all
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This introduces a Github Action that automatically scans the whole codebase for typos and automatically adds a Pull Request suggesting those code changes.

## What is the current behavior?

No CI to prevent typos.

## What is the new behavior?

With a Github Action to prevent typos, we can avoid typos in the codebase which results in saving time updating either code or docs with typos.

<img width="798" alt="Captura de ecrã 2023-02-02, às 15 59 15" src="https://user-images.githubusercontent.com/29093946/216375588-91d87e66-57f4-4c9f-92ae-556925d1eb3b.png">

