### PR TITLE
Fix short article column layout

### DIFF
--- a/external/.scroll.css
+++ b/external/.scroll.css
@@ -253,12 +253,13 @@ center .scrollParagraph {
 
 .scrollColumns {
   column-count: auto;
-  column-fill: balance;
+  column-fill: auto;
   column-width: 35ch;
   column-gap: 1.5rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   margin: auto;
+  min-height: 100vh;
 }
 
 .scrollSnippetContainer {


### PR DESCRIPTION
/claim #32

Fixes #32.

## Summary
- Change Scroll column layout to fill columns vertically before balancing into extra columns.
- Give short article column containers a viewport-height minimum so one-page articles no longer spread sparse content across too many columns.

## Verification
- `node -e "const fs=require('fs'); const css=fs.readFileSync('external/.scroll.css','utf8'); console.log(css.includes('column-fill: auto;') && css.includes('min-height: 100vh;') ? 'css check passed' : 'css check failed')"`

## Notes
- `npm test` and `npm run build` currently fail on this checkout before this CSS change because the installed `scrollsdk` exposes `scrollProgram` without the `load()` method expected by `scroll.js`.